### PR TITLE
fix(test): Fix failing test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -178,7 +178,7 @@ test('installPackages unit', t => {
     }, err => {
       t.match(
         err.message,
-        /Install for codefail failed with code 123/,
+        /Install for .{0,3}codefail.{0,3} failed with code 123/,
         'npm install failure has helpful error message'
       )
       t.equal(err.exitCode, 123, 'error has exitCode')


### PR DESCRIPTION
test fails because different versions produce different error messages:
`Install for codefail failed with code 123`
or
`Install for [ 'codefail' ] failed with code 123`
Fixed regexp to match both

<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼
-->
