### PR TITLE
meta: Link to new github repository from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
   },
-  "repository": "https://github.com/zkat/npx",
+  "repository": "https://github.com/npm/npx",
   "keywords": [
     "npm",
     "npm exec",


### PR DESCRIPTION
The npm page links to the archived repository at zkat/npx

Have switched the URL to make everything a bit clearer.