### PR TITLE
feat: add warn on wrong shebang

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,9 +339,13 @@ function findNodeScript (existing, opts) {
           }, err => {
             return promisify(fs.close)(fd).then(() => { throw err })
           })
-        }).then(() => {
-          const re = /#!\s*(?:\/usr\/bin\/env\s*node|\/usr\/local\/bin\/node|\/usr\/bin\/node)\s*\r?\n/i
-          return buf.toString('utf8').match(re) && existing
+        }).then(function executableHeaderExists () {
+          const executableHeader = /#!\s*(?:\/usr\/bin\/env\s*node|\/usr\/local\/bin\/node|\/usr\/bin\/node)\s*\r?\n/i
+          if (buf.toString('utf8').match(executableHeader)) {
+            return existing
+          } else {
+            throw new Error(Y()`Expected shebang not found, check if ${existing} contains: "#!/usr/bin/env node"`)
+          }
         })
       } else if (process.platform === 'win32') {
         const buf = Buffer.alloc(1000)

--- a/locales/en.json
+++ b/locales/en.json
@@ -26,5 +26,6 @@
   "npx: installed %s in %ss": "npx: installed %s in %ss",
   "Suppress output from npx itself. Subcommands will not be affected.": "Suppress output from npx itself. Subcommands will not be affected.",
   "Extra node argument when calling a node binary.": "Extra node argument when calling a node binary.",
-  "Always spawn a child process to execute the command.": "Always spawn a child process to execute the command."
+  "Always spawn a child process to execute the command.": "Always spawn a child process to execute the command.",
+  "Expected shebang not found, check if %s contains: \"#!/usr/bin/env node\"": "Expected shebang not found, check if %s contains: \"#!/usr/bin/env node\""
 }

--- a/test/index.js
+++ b/test/index.js
@@ -242,9 +242,13 @@ test('findNodeScript', t => {
     } else {
       t.equal(script, NPX_PATH, 'existing returned as-is on *nix')
     }
-    return main._findNodeScript(__filename).then(script => {
-      t.notOk(script, 'files that are not standalone node scripts are false')
-    })
+    return main._findNodeScript(__filename)
+      .then(script => {
+        t.fail('files that are not standalone node scripts should trigger error')
+      })
+      .catch(err => {
+        t.equal(err.message, `Expected shebang not found, check if ${__filename} contains: "#!/usr/bin/env node"`)
+      })
   }).then(() => {
     return main._findNodeScript(null).then(bool => {
       t.notOk(bool, 'no node script found if existing is null')


### PR DESCRIPTION
I added Error which is thrown if the executed script contains wrong shebang.
Without it people could spend a lot of time searching why:
"npx: command not found: create-bulky-start"
when in fact command exists but is silently invalidated by npx.

Looking for this bug brought physical pain upon me, 
I hope that this patch will protect people from one I experienced.

Cheers.