### PR TITLE
fix(index): npx log install result to stdout not in stderr

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function npx (argv) {
         // Some npm packages need to be installed. Let's install them!
         return ensurePackages(argv.package, argv).then(results => {
           if (results && results.added && results.updated && !argv.q) {
-            console.error(Y()`npx: installed ${
+            console.log(Y()`npx: installed ${
               results.added.length + results.updated.length
             } in ${(Date.now() - startTime) / 1000}s`)
           }


### PR DESCRIPTION
BREAKING CHANGE: some automatization may expect old behavior

# What / Why
> installed is success and will be write to stdout, not in stderr

## References
* similar to https://github.com/npm/cli/pull/79
